### PR TITLE
Update CMakePresets

### DIFF
--- a/.github/workflows/iar.yml
+++ b/.github/workflows/iar.yml
@@ -58,16 +58,16 @@ jobs:
     - name: CMake - Configure Ninja preset
       run: cmake --preset ninja
     - name: CMake - Build Debug preset
-      run: cmake --build --preset debug-ninja --verbose
+      run: cmake --build --preset debug-ninja --clean-first --verbose
     - name: CMake - Build Release preset
-      run: cmake --build --preset release-ninja --verbose
+      run: cmake --build --preset release-ninja --clean-first --verbose
     - name: CMake - Build Release With Debug Info preset
-      run: cmake --build --preset relwithdebinfo-ninja --verbose
+      run: cmake --build --preset relwithdebinfo-ninja --clean-first --verbose
     - name: CMake - Build Minimum Size Release preset
-      run: cmake --build --preset minsizerel-ninja --verbose
+      run: cmake --build --preset minsizerel-ninja --clean-first --verbose
     - name: CMake - Build Medium Speed preset
-      run: cmake --build --preset medium-ninja --verbose
+      run: cmake --build --preset medium-ninja --clean-first --verbose
     - name: CMake - Build High Speed preset
-      run: cmake --build --preset highspeed-ninja --verbose
+      run: cmake --build --preset highspeed-ninja --clean-first --verbose
     - name: CMake - Build Maximum Speed preset
-      run: cmake --build --preset maxspeed-ninja --verbose
+      run: cmake --build --preset maxspeed-ninja --clean-first --verbose

--- a/.github/workflows/iar.yml
+++ b/.github/workflows/iar.yml
@@ -19,7 +19,7 @@ env:
 
 jobs:
   build-ninja-multi:
-    name: Build
+    name: Build Ninja Multi-Config
     runs-on: ubuntu-24.04
     container:
       image: ghcr.io/iarsystems/riscv
@@ -46,7 +46,7 @@ jobs:
       run: cmake --build --preset maxspeed-ninja-multi --verbose
 
   build-ninja:
-    name: Build
+    name: Build Ninja
     runs-on: ubuntu-24.04
     container:
       image: ghcr.io/iarsystems/riscv

--- a/.github/workflows/iar.yml
+++ b/.github/workflows/iar.yml
@@ -60,7 +60,7 @@ jobs:
     - name: CMake - Build Debug preset
       run: cmake --build --preset debug-ninja --verbose
     - name: CMake - Build Release preset
-      run: cmake --build --preset release-ninja- --verbose
+      run: cmake --build --preset release-ninja --verbose
     - name: CMake - Build Release With Debug Info preset
       run: cmake --build --preset relwithdebinfo-ninja --verbose
     - name: CMake - Build Minimum Size Release preset

--- a/.github/workflows/iar.yml
+++ b/.github/workflows/iar.yml
@@ -18,7 +18,7 @@ env:
   IAR_LMS_BEARER_TOKEN: ${{ secrets.IAR_LMS_BEARER_TOKEN }}
 
 jobs:
-  build:
+  build-ninja-multi:
     name: Build
     runs-on: ubuntu-24.04
     container:
@@ -28,18 +28,46 @@ jobs:
       run: iccriscv --version
     - name: Checkout project
       uses: actions/checkout@v6
-    - name: CMake - Configure CXRISCV preset
-      run: cmake --preset cxriscv
+    - name: CMake - Configure Ninja Multi-Config preset
+      run: cmake --preset ninja-multi
     - name: CMake - Build Debug preset
-      run: cmake --build --preset debug --verbose
+      run: cmake --build --preset debug-ninja-multi --verbose
     - name: CMake - Build Release preset
-      run: cmake --build --preset release --verbose
+      run: cmake --build --preset release-ninja-multi --verbose
     - name: CMake - Build Release With Debug Info preset
-      run: cmake --build --preset relwithdebinfo --verbose
+      run: cmake --build --preset relwithdebinfo-ninja-multi --verbose
     - name: CMake - Build Minimum Size Release preset
-      run: cmake --build --preset minsizerel --verbose
+      run: cmake --build --preset minsizerel-ninja-multi --verbose
+    - name: CMake - Build Medium Speed preset
+      run: cmake --build --preset medium-ninja-multi --verbose
     - name: CMake - Build High Speed preset
-      run: cmake --build --preset highspeed --verbose
+      run: cmake --build --preset highspeed-ninja-multi --verbose
     - name: CMake - Build Maximum Speed preset
-      run: cmake --build --preset maxspeed --verbose
+      run: cmake --build --preset maxspeed-ninja-multi --verbose
 
+  build-ninja:
+    name: Build
+    runs-on: ubuntu-24.04
+    container:
+      image: ghcr.io/iarsystems/riscv
+    steps:
+    - name: Invoke the IAR C/C++ Compiler for RISC-V
+      run: iccriscv --version
+    - name: Checkout project
+      uses: actions/checkout@v6
+    - name: CMake - Configure Ninja preset
+      run: cmake --preset ninja
+    - name: CMake - Build Debug preset
+      run: cmake --build --preset debug-ninja --verbose
+    - name: CMake - Build Release preset
+      run: cmake --build --preset release-ninja- --verbose
+    - name: CMake - Build Release With Debug Info preset
+      run: cmake --build --preset relwithdebinfo-ninja --verbose
+    - name: CMake - Build Minimum Size Release preset
+      run: cmake --build --preset minsizerel-ninja --verbose
+    - name: CMake - Build Medium Speed preset
+      run: cmake --build --preset medium-ninja --verbose
+    - name: CMake - Build High Speed preset
+      run: cmake --build --preset highspeed-ninja --verbose
+    - name: CMake - Build Maximum Speed preset
+      run: cmake --build --preset maxspeed-ninja --verbose

--- a/.github/workflows/iar.yml
+++ b/.github/workflows/iar.yml
@@ -27,7 +27,7 @@ jobs:
     - name: Invoke the IAR C/C++ Compiler for RISC-V
       run: iccriscv --version
     - name: Checkout project
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
     - name: CMake - Configure CXRISCV preset
       run: cmake --preset cxriscv
     - name: CMake - Build Debug preset

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,22 @@ include(iar-cxriscv)
 
 # Configure a CMake project
 project(iar-gd32v-examples)
+
+# Enable CTest
 enable_testing()
+
+# Enable IAR C-STAT Static Analysis
+option(ENABLE_ICSTAT "Enable IAR C-STAT Static Analysis" OFF)
+if(ENABLE_ICSTAT)
+  set(CMAKE_C_ICSTAT "${CMAKE_IAR_CSTAT}")
+  set(CMAKE_CXX_ICSTAT "${CMAKE_IAR_CSTAT}")
+endif()
+
+# Enable IAR Compiler extensions (-e)
+set(CMAKE_C_EXTENSIONS ON)
+
+# Set the TOOLKIT directory
+cmake_path(GET CMAKE_C_COMPILER PARENT_PATH BIN_DIR)
+cmake_path(GET BIN_DIR PARENT_PATH TOOLKIT_DIR)
 
 add_subdirectory(examples)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,6 +18,7 @@ endif()
 
 # Enable IAR Compiler extensions (-e)
 set(CMAKE_C_EXTENSIONS ON)
+set(CMAKE_CXX_EXTENSIONS ON)
 
 # Set the TOOLKIT directory
 cmake_path(GET CMAKE_C_COMPILER PARENT_PATH BIN_DIR)

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -136,7 +136,6 @@
         },
         {
             "name": "highspeed-ninja-multi",
-            "displayName": "HighSpeed",
             "description": "Optimize for high execution speed - exclude debug information.",
             "configurePreset": "ninja-multi",
             "configuration": "HighSpeed"

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -2,97 +2,110 @@
     "version": 10,
     "configurePresets": [
         {
-            "name": "common",
+            "name": "common-base",
             "hidden": true,
+            "binaryDir": "${sourceDir}/build",
             "cacheVariables": {
-                "CMAKE_EXPORT_COMPILE_COMMANDS":true
+                "CMAKE_SYSTEM_NAME": {
+                    "type": "STRING",
+                    "value": "Generic"
+                },
+                "CMAKE_STATIC_LIBRARY_PREFIX": {
+                    "type": "STRING",
+                    "value": ""
+                },
+                "CMAKE_C_FLAGS_MEDIUM": {
+                    "type": "STRING",
+                    "value": "-Om -DNDEBUG"
+                },
+                "CMAKE_CXX_FLAGS_MEDIUM": {
+                    "type": "STRING",
+                    "value": "-Om -DNDEBUG"
+                },
+                "CMAKE_C_FLAGS_HIGHSPEED": {
+                    "type": "STRING",
+                    "value": "-Ohs -DNDEBUG"
+                },
+                "CMAKE_CXX_FLAGS_HIGHSPEED": {
+                    "type": "STRING",
+                    "value": "-Ohs -DNDEBUG"
+                },
+                "CMAKE_C_FLAGS_MAXSPEED": {
+                    "type": "STRING",
+                    "value": "-Ohs --no_size_constraints -DNDEBUG"
+                },
+                "CMAKE_CXX_FLAGS_MAXSPEED": {
+                    "type": "STRING",
+                    "value": "-Ohs --no_size_constraints -DNDEBUG"
+                },
+                "IAR_RT_LLIO_ARM": {
+                    "type": "STRING",
+                    "value": "--semihosting"
+                },
+                "IAR_RT_LLIO_RISCV": {
+                    "type": "STRING",
+                    "value": "--semihosting"
+                },
+                "IAR_RT_LLIO_RH850": {
+                    "type": "STRING",
+                    "value": "--debug_lib"
+                },
+                "IAR_RT_LLIO_RL78": {
+                    "type": "STRING",
+                    "value": "--debug_lib"
+                },
+                "IAR_RT_LLIO_RX": {
+                    "type": "STRING",
+                    "value": "--debug_lib"
+                }
             },
-            "generator": "Ninja Multi-Config",
-            "binaryDir": "${sourceDir}/build"
-        },
-        {
-            "name": "cxriscv",
-            "displayName": "CXRISCV",
-            "description": "Configure project for CXRISCV",
-            "inherits": "common",
-            "condition": {
-                "type": "equals",
-                "lhs": "${hostSystemName}",
-                "rhs": "Linux"
-            },
-            "environment": {
-                "CC":  "/opt/iar/cxriscv/riscv/bin/iccriscv",
-                "CXX": "/opt/iar/cxriscv/riscv/bin/iccriscv",
-                "ASM": "/opt/iar/cxriscv/riscv/bin/iasmriscv"
-            },
-            "cacheVariables": {
-                "SELECTED_TOOL": "cxriscv",
-                "TOOLKIT_DIR": "/opt/iar/cxriscv/riscv"
+            "warnings": {
+                "unusedCli": false
             }
         },
         {
-            "name": "bxriscv",
-            "displayName": "BXRISCV",
-            "description": "Configure project for BXRISCV",
-            "inherits": "common",
-            "condition": {
-                "type": "equals",
-                "lhs": "${hostSystemName}",
-                "rhs": "Linux"
-            },
-            "environment": {
-                "CC":  "/opt/iarsystems/bxriscv/riscv/bin/iccriscv",
-                "CXX": "/opt/iarsystems/bxriscv/riscv/bin/iccriscv",
-                "ASM": "/opt/iarsystems/bxriscv/riscv/bin/iasmriscv"
-            },
+            "name": "ninja-multi",
+            "inherits": "common-base",
+            "displayName": "Ninja Multi-Config",
+            "description": "Configure a CMake project using the Ninja Multi-Config Generator.",
+            "generator": "Ninja Multi-Config",
             "cacheVariables": {
-                "SELECTED_TOOL": "bxriscv",
-                "TOOLKIT_DIR": "/opt/iarsystems/bxriscv/riscv"
+                "CMAKE_CONFIGURATION_TYPES": {
+                    "type": "STRING",
+                    "value": "Debug;Release;RelWithDebInfo;MinSizeRel;Medium;HighSpeed;MaxSpeed"
+                },
+                "CMAKE_PRESET_NAME": {
+                    "type": "STRING",
+                    "value": "ninja-multi"
+                }
+            }
+        },
+        {
+            "name": "ninja",
+            "inherits": "common-base",
+            "displayName": "Ninja",
+            "description": "Configure a CMake project using the Ninja Generator.",
+            "generator": "Ninja",
+            "cacheVariables": {
+                "CMAKE_BUILD_TYPE": {
+                    "type": "STRING",
+                    "value": "Debug"
+                },
+                "CMAKE_PRESET_NAME": {
+                    "type": "STRING",
+                    "value": "ninja-multi"
+                }
             }
         }
     ],
     "buildPresets": [
         {
-            "name": "debug",
-            "displayName": "Debug",
-            "description": "Disable optimizations - include debug information.",
-            "configurePreset": "cxriscv",
-            "configuration": "Debug"
+            "name": "ninja-multi",
+            "configurePreset": "ninja-multi"
         },
         {
-            "name": "release",
-            "displayName": "Release",
-            "description": "Optimize for speed - exclude debug information.",
-            "configurePreset": "cxriscv",
-            "configuration": "Release"
-        },
-        {
-            "name": "relwithdebinfo",
-            "displayName": "RelWithDebInfo",
-            "description": "Optimize for speed - include debug information.",
-            "configurePreset": "cxriscv",
-            "configuration": "RelWithDebInfo"
-        },
-        {
-            "name": "minsizerel",
-            "displayName": "MinSizeRel",
-            "description": "Optimize for smallest binary size - exclude debug information.",
-            "configurePreset": "cxriscv",
-            "configuration": "MinSizeRel"
-        },
-        {
-            "name": "highspeed",
-            "displayName": "HighSpeed",
-            "description": "Optimize for high execution speed - exclude debug information.",
-            "configurePreset": "cxriscv",
-            "configuration": "HighSpeed"
-        },
-        {
-            "name": "maxspeed",
-            "displayName": "MaxSpeed",
-            "description": "Optimize for maximum execution speed - exclude debug information.",
-            "configurePreset": "cxriscv",
-            "configuration": "MaxSpeed"
+            "name": "ninja",
+            "configurePreset": "ninja"
         }
     ]
 }

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -136,6 +136,7 @@
         },
         {
             "name": "highspeed-ninja-multi",
+            "displayName": "HighSpeed",
             "description": "Optimize for high execution speed - exclude debug information.",
             "configurePreset": "ninja-multi",
             "configuration": "HighSpeed"

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -100,12 +100,102 @@
     ],
     "buildPresets": [
         {
-            "name": "ninja-multi",
-            "configurePreset": "ninja-multi"
+            "name": "debug-ninja-multi",
+            "displayName": "Debug",
+            "description": "Disable optimizations - include debug information.",
+            "configurePreset": "ninja-multi",
+            "configuration": "Debug"
         },
         {
-            "name": "ninja",
-            "configurePreset": "ninja"
+            "name": "release-ninja-multi",
+            "displayName": "Release",
+            "description": "Optimize for speed - exclude debug information.",
+            "configurePreset": "ninja-multi",
+            "configuration": "Release"
+        },
+        {
+            "name": "relwithdebinfo-ninja-multi",
+            "displayName": "RelWithDebInfo",
+            "description": "Optimize for speed - include debug information.",
+            "configurePreset": "ninja-multi",
+            "configuration": "RelWithDebInfo"
+        },
+        {
+            "name": "minsizerel-ninja-multi",
+            "displayName": "MinSizeRel",
+            "description": "Optimize for smallest binary size - exclude debug information.",
+            "configurePreset": "ninja-multi",
+            "configuration": "MinSizeRel"
+        },
+        {
+            "name": "medium-ninja-multi",
+            "displayName": "Medium",
+            "description": "Optimize for medium execution speed - exclude debug information.",
+            "configurePreset": "ninja-multi",
+            "configuration": "Medium"
+        },
+        {
+            "name": "highspeed-ninja-multi",
+            "displayName": "HighSpeed",
+            "description": "Optimize for high execution speed - exclude debug information.",
+            "configurePreset": "ninja-multi",
+            "configuration": "HighSpeed"
+        },
+        {
+            "name": "maxspeed-ninja-multi",
+            "displayName": "MaxSpeed",
+            "description": "Optimize for maximum execution speed - exclude debug information.",
+            "configurePreset": "ninja-multi",
+            "configuration": "MaxSpeed"
+        },
+        {
+            "name": "debug-ninja",
+            "displayName": "Debug",
+            "description": "Disable optimizations - include debug information.",
+            "configurePreset": "ninja",
+            "configuration": "Debug"
+        },
+        {
+            "name": "release-ninja",
+            "displayName": "Release",
+            "description": "Optimize for speed - exclude debug information.",
+            "configurePreset": "ninja",
+            "configuration": "Release"
+        },
+        {
+            "name": "relwithdebinfo-ninja",
+            "displayName": "RelWithDebInfo",
+            "description": "Optimize for speed - include debug information.",
+            "configurePreset": "ninja",
+            "configuration": "RelWithDebInfo"
+        },
+        {
+            "name": "minsizerel-ninja",
+            "displayName": "MinSizeRel",
+            "description": "Optimize for smallest binary size - exclude debug information.",
+            "configurePreset": "ninja",
+            "configuration": "MinSizeRel"
+        },
+        {
+            "name": "medium-ninja",
+            "displayName": "Medium",
+            "description": "Optimize for medium execution speed - exclude debug information.",
+            "configurePreset": "ninja",
+            "configuration": "Medium"
+        },
+        {
+            "name": "highspeed-ninja",
+            "displayName": "HighSpeed",
+            "description": "Optimize for high execution speed - exclude debug information.",
+            "configurePreset": "ninja",
+            "configuration": "HighSpeed"
+        },
+        {
+            "name": "maxspeed-ninja",
+            "displayName": "MaxSpeed",
+            "description": "Optimize for maximum execution speed - exclude debug information.",
+            "configurePreset": "ninja",
+            "configuration": "MaxSpeed"
         }
     ]
 }

--- a/cmake/iar-cxriscv.cmake
+++ b/cmake/iar-cxriscv.cmake
@@ -5,7 +5,7 @@ macro(iar_cspysim TARGET)
   find_program(CSPYBAT
     NAMES CSpyBat
     HINTS "${TOOLKIT_DIR}/.."
-    PATH_SUFFIXES common/bin
+    PATH_SUFFIXES "common/bin"
     REQUIRED
   )
 
@@ -14,7 +14,7 @@ macro(iar_cspysim TARGET)
   find_library(LIBPROC
     NAMES libriscvproc.so
     HINTS ${TOOLKIT_DIR}
-    PATH_SUFFIXES riscv/bin
+    PATH_SUFFIXES bin
     REQUIRED
   )
   find_library(LIBSIM
@@ -30,8 +30,7 @@ macro(iar_cspysim TARGET)
     REQUIRED
   )
 
-  add_test(
-    NAME ${TARGET}
+  add_test(NAME ${TARGET}
     COMMAND ${CSPYBAT} ${LIBPROC} ${LIBSIM}
       --plugin=${LIBSUPPORT}
       --debug_file=$<TARGET_FILE:${TARGET}>

--- a/cmake/iar-cxriscv.cmake
+++ b/cmake/iar-cxriscv.cmake
@@ -1,57 +1,32 @@
 include_guard()
 
-# Set CMake for cross-compiling
-set(CMAKE_SYSTEM_NAME Generic)
-
-# Enable all CMake default build configurations
-list(APPEND CMAKE_CONFIGURATION_TYPES Debug)
-list(APPEND CMAKE_CONFIGURATION_TYPES Release)
-list(APPEND CMAKE_CONFIGURATION_TYPES RelWithDebInfo)
-list(APPEND CMAKE_CONFIGURATION_TYPES MinSizeRel)
-
-# Add IAR C/C++ Compiler custom configuration for High Speed
-list(APPEND CMAKE_CONFIGURATION_TYPES HighSpeed)
-set(CMAKE_C_FLAGS_HIGHSPEED " -Ohs" CACHE INTERNAL "")
-set(CMAKE_CXX_FLAGS_HIGHSPEED " -Ohs" CACHE INTERNAL "")
-
-# Add IAR C/C++ Compiler custom configuration for Maximum Speed
-list(APPEND CMAKE_CONFIGURATION_TYPES MaxSpeed)
-set(CMAKE_C_FLAGS_MAXSPEED " -Ohs --no_size_constraints" CACHE INTERNAL "")
-set(CMAKE_CXX_FLAGS_MAXSPEED " -Ohs --no_size_constraints" CACHE INTERNAL "")
-
-# Enable IAR C-STAT Static Analysis
-option(ENABLE_ICSTAT "Enable IAR C-STAT Static Analysis" OFF)
-if(ENABLE_ICSTAT)
-  set(CMAKE_C_ICSTAT "${CMAKE_IAR_CSTAT}")
-  set(CMAKE_CXX_ICSTAT "${CMAKE_IAR_CSTAT}")
-endif()
-
 # Facilitate adding C-SPY tests driven by CTest
 macro(iar_cspysim TARGET)
   find_program(CSPYBAT
     NAMES CSpyBat
-    HINTS /opt/iar/cxriscv /opt/iarsystems/bxriscv
+    HINTS "${TOOLKIT_DIR}/.."
     PATH_SUFFIXES common/bin
     REQUIRED
   )
+
   cmake_path(GET CSPYBAT PARENT_PATH COMMON_DIR)
 
   find_library(LIBPROC
     NAMES libriscvproc.so
-    HINTS /opt/iar/cxriscv /opt/iarsystems/bxriscv
+    HINTS ${TOOLKIT_DIR}
     PATH_SUFFIXES riscv/bin
     REQUIRED
   )
   find_library(LIBSIM
     NAMES libriscvsim.so libriscvSIM.so
-    HINTS /opt/iar/cxriscv /opt/iarsystems/bxriscv
-    PATH_SUFFIXES riscv/bin
+    HINTS ${TOOLKIT_DIR}
+    PATH_SUFFIXES bin
     REQUIRED
   )
   find_library(LIBSUPPORT
     NAMES libriscvlibsupport.so
-    HINTS /opt/iar/cxriscv /opt/iarsystems/bxriscv
-    PATH_SUFFIXES riscv/bin
+    HINTS ${TOOLKIT_DIR}
+    PATH_SUFFIXES bin
     REQUIRED
   )
 
@@ -63,7 +38,9 @@ macro(iar_cspysim TARGET)
       --silent
       --backend
         --core=RV32IMAC
-        --semihosting )
+        --semihosting
+  )
+
   # SUCCESS is the expected output from acutest
   set_property(TEST ${TARGET} PROPERTY PASS_REGULAR_EXPRESSION SUCCESS)
 endmacro()
@@ -71,12 +48,9 @@ endmacro()
 # Generate additional outputs
 function(iar_elftool tgt)
   add_custom_command(TARGET ${tgt} POST_BUILD
-    COMMAND ${CMAKE_IAR_ELFTOOL} --silent --strip --ihex $<TARGET_FILE:${tgt}> $<CONFIG>/$<TARGET_PROPERTY:${tgt},NAME>.hex
-    COMMAND ${CMAKE_IAR_ELFTOOL} --silent --strip --srec $<TARGET_FILE:${tgt}> $<CONFIG>/$<TARGET_PROPERTY:${tgt},NAME>.srec
-    COMMAND ${CMAKE_IAR_ELFTOOL} --silent --strip --bin $<TARGET_FILE:${tgt}> $<CONFIG>/$<TARGET_PROPERTY:${tgt},NAME>.bin
-)
+    COMMAND ${CMAKE_IAR_ELFTOOL} --silent --strip --ihex $<TARGET_FILE:${tgt}> $<TARGET_FILE_DIR:${tgt}>/${tgt}.hex
+    COMMAND ${CMAKE_IAR_ELFTOOL} --silent --strip --srec $<TARGET_FILE:${tgt}> $<TARGET_FILE_DIR:${tgt}>/${tgt}.srec
+    COMMAND ${CMAKE_IAR_ELFTOOL} --silent --strip --bin  $<TARGET_FILE:${tgt}> $<TARGET_FILE_DIR:${tgt}>/${tgt}.bin
+  )
 endfunction()
 
-# Touch the cachedVariables from CMakePresets
-set(TOOLKIT_DIR ${TOOLKIT_DIR})
-set(SELECTED_TOOL ${SELECTED_TOOL})

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,4 +1,5 @@
 # Add subdirectories
+
 add_subdirectory(accelerometer)
 add_subdirectory(coremark)
 add_subdirectory(leds)

--- a/examples/accelerometer/CMakeLists.txt
+++ b/examples/accelerometer/CMakeLists.txt
@@ -32,17 +32,15 @@ target_include_directories(${EXAMPLE} PRIVATE
 
 target_compile_options(${EXAMPLE} PRIVATE
   --core=RV32IMAC
-  --dlib_config=normal
-  -e
+  --dlib_config=full
   --no_wrap_diagnostics
-  --nonportable_path_warnings
 )
 
 target_link_options(${EXAMPLE} PRIVATE
-  --config /opt/iar/cxriscv/riscv/config/linker/GD/GD32VF103xB.icf
+  --config ${TOOLKIT_DIR}/config/linker/GD/GD32VF103xB.icf
   "SHELL:--config_def CSTACK_SIZE=0x1000"
   "SHELL:--config_def HEAP_SIZE=0x1000"
   --redirect __write=__write_buffered
   --debug_lib=iar_breakpoint
-  --map .
+  --map $<TARGET_FILE_DIR:${EXAMPLE}>
 )

--- a/examples/coremark/CMakeLists.txt
+++ b/examples/coremark/CMakeLists.txt
@@ -41,9 +41,8 @@ target_include_directories(${EXAMPLE} PRIVATE
 
 target_compile_options(${EXAMPLE} PRIVATE
   --core=RV32IMAC
-  -e
+  --dlib_config=full
   --no_wrap_diagnostics
-  --nonportable_path_warnings
 )
 
 target_link_options(${EXAMPLE} PRIVATE
@@ -52,5 +51,5 @@ target_link_options(${EXAMPLE} PRIVATE
   "SHELL:--config_def HEAP_SIZE=0x1000"
   --redirect __write=__write_buffered
   --debug_lib=iar_breakpoint
-  --map .
+  --map $<TARGET_FILE_DIR:${EXAMPLE}>
 )

--- a/examples/leds-cpp/CMakeLists.txt
+++ b/examples/leds-cpp/CMakeLists.txt
@@ -31,16 +31,15 @@ target_include_directories(${EXAMPLE} PRIVATE
 
 target_compile_options(${EXAMPLE} PRIVATE
   --core=RV32IMAC
-  -e
+  --dlib_config=full
   --no_wrap_diagnostics
-  --nonportable_path_warnings
 )
 
 target_link_options(${EXAMPLE} PRIVATE
-  --config /opt/iar/cxriscv/riscv/config/linker/GD/GD32VF103xB.icf
+  --config ${TOOLKIT_DIR}/config/linker/GD/GD32VF103xB.icf
   "SHELL:--config_def CSTACK_SIZE=0x1000"
   "SHELL:--config_def HEAP_SIZE=0x1000"
   --redirect __write=__write_buffered
   --debug_lib=iar_breakpoint
-  --map .
+  --map $<TARGET_FILE_DIR:${EXAMPLE}>
 )

--- a/examples/leds/CMakeLists.txt
+++ b/examples/leds/CMakeLists.txt
@@ -32,16 +32,15 @@ target_include_directories(${EXAMPLE} PRIVATE
 
 target_compile_options(${EXAMPLE} PRIVATE
   --core=RV32IMAC
-  -e
+  --dlib_config=full
   --no_wrap_diagnostics
-  --nonportable_path_warnings
 )
 
 target_link_options(${EXAMPLE} PRIVATE
-  --config /opt/iar/cxriscv/riscv/config/linker/GD/GD32VF103xB.icf
+  --config ${TOOLKIT_DIR}/config/linker/GD/GD32VF103xB.icf
   "SHELL:--config_def CSTACK_SIZE=0x1000"
   "SHELL:--config_def HEAP_SIZE=0x1000"
   --redirect __write=__write_buffered
   --debug_lib=iar_breakpoint
-  --map .
+  --map $<TARGET_FILE_DIR:${EXAMPLE}>
 )

--- a/examples/potentiometer/CMakeLists.txt
+++ b/examples/potentiometer/CMakeLists.txt
@@ -32,16 +32,15 @@ target_include_directories(${EXAMPLE} PRIVATE
 
 target_compile_options(${EXAMPLE} PRIVATE
   --core=RV32IMAC
-  -e
+  --dlib_config=full
   --no_wrap_diagnostics
-  --nonportable_path_warnings
 )
 
 target_link_options(${EXAMPLE} PRIVATE
-  --config /opt/iar/cxriscv/riscv/config/linker/GD/GD32VF103xB.icf
+  --config ${TOOLKIT_DIR}/config/linker/GD/GD32VF103xB.icf
   "SHELL:--config_def CSTACK_SIZE=0x1000"
   "SHELL:--config_def HEAP_SIZE=0x1000"
   --redirect __write=__write_buffered
   --debug_lib=iar_breakpoint
-  --map .
+  --map $<TARGET_FILE_DIR:${EXAMPLE}>
 )

--- a/examples/rgb-led/CMakeLists.txt
+++ b/examples/rgb-led/CMakeLists.txt
@@ -32,16 +32,15 @@ target_include_directories(${EXAMPLE} PRIVATE
 
 target_compile_options(${EXAMPLE} PRIVATE
   --core=RV32IMAC
-  -e
+  --dlib_config=full
   --no_wrap_diagnostics
-  --nonportable_path_warnings
 )
 
 target_link_options(${EXAMPLE} PRIVATE
-  --config /opt/iar/cxriscv/riscv/config/linker/GD/GD32VF103xB.icf
+  --config ${TOOLKIT_DIR}/config/linker/GD/GD32VF103xB.icf
   "SHELL:--config_def CSTACK_SIZE=0x1000"
   "SHELL:--config_def HEAP_SIZE=0x1000"
   --redirect __write=__write_buffered
   --debug_lib=iar_breakpoint
-  --map .
+  --map $<TARGET_FILE_DIR:${EXAMPLE}>
 )

--- a/examples/spi-flash/CMakeLists.txt
+++ b/examples/spi-flash/CMakeLists.txt
@@ -32,16 +32,15 @@ target_include_directories(${EXAMPLE} PRIVATE
 
 target_compile_options(${EXAMPLE} PRIVATE
   --core=RV32IMAC
-  -e
+  --dlib_config=full
   --no_wrap_diagnostics
-  --nonportable_path_warnings
 )
 
 target_link_options(${EXAMPLE} PRIVATE
-  --config /opt/iar/cxriscv/riscv/config/linker/GD/GD32VF103xB.icf
+  --config ${TOOLKIT_DIR}/config/linker/GD/GD32VF103xB.icf
   "SHELL:--config_def CSTACK_SIZE=0x1000"
   "SHELL:--config_def HEAP_SIZE=0x1000"
   --redirect __write=__write_buffered
   --debug_lib=iar_breakpoint
-  --map .
+  --map $<TARGET_FILE_DIR:${EXAMPLE}>
 )

--- a/examples/switches-interrupt/CMakeLists.txt
+++ b/examples/switches-interrupt/CMakeLists.txt
@@ -38,16 +38,15 @@ target_include_directories(${EXAMPLE} PRIVATE
 
 target_compile_options(${EXAMPLE} PRIVATE
   --core=RV32IMAC
-  -e
+  --dlib_config=full
   --no_wrap_diagnostics
-  --nonportable_path_warnings
 )
 
 target_link_options(${EXAMPLE} PRIVATE
-  --config /opt/iar/cxriscv/riscv/config/linker/GD/GD32VF103xB.icf
+  --config ${TOOLKIT_DIR}/config/linker/GD/GD32VF103xB.icf
   "SHELL:--config_def CSTACK_SIZE=0x1000"
   "SHELL:--config_def HEAP_SIZE=0x1000"
   --redirect __write=__write_buffered
   --debug_lib=iar_breakpoint
-  --map .
+  --map $<TARGET_FILE_DIR:${EXAMPLE}>
 )

--- a/examples/switches/CMakeLists.txt
+++ b/examples/switches/CMakeLists.txt
@@ -33,16 +33,15 @@ target_include_directories(${EXAMPLE} PRIVATE
 
 target_compile_options(${EXAMPLE} PRIVATE
   --core=RV32IMAC
-  -e
+  --dlib_config=full
   --no_wrap_diagnostics
-  --nonportable_path_warnings
 )
 
 target_link_options(${EXAMPLE} PRIVATE
-  --config /opt/iar/cxriscv/riscv/config/linker/GD/GD32VF103xB.icf
+  --config ${TOOLKIT_DIR}/config/linker/GD/GD32VF103xB.icf
   "SHELL:--config_def CSTACK_SIZE=0x1000"
   "SHELL:--config_def HEAP_SIZE=0x1000"
   --redirect __write=__write_buffered
   --debug_lib=iar_breakpoint
-  --map .
+  --map $<TARGET_FILE_DIR:${EXAMPLE}>
 )

--- a/examples/temperature-humidity/CMakeLists.txt
+++ b/examples/temperature-humidity/CMakeLists.txt
@@ -38,16 +38,15 @@ target_include_directories(${EXAMPLE} PRIVATE
 
 target_compile_options(${EXAMPLE} PRIVATE
   --core=RV32IMAC
-  -e
+  --dlib_config=full
   --no_wrap_diagnostics
-  --nonportable_path_warnings
 )
 
 target_link_options(${EXAMPLE} PRIVATE
-  --config /opt/iar/cxriscv/riscv/config/linker/GD/GD32VF103xB.icf
+  --config ${TOOLKIT_DIR}/config/linker/GD/GD32VF103xB.icf
   "SHELL:--config_def CSTACK_SIZE=0x1000"
   "SHELL:--config_def HEAP_SIZE=0x1000"
   --redirect __write=__write_buffered
   --debug_lib=iar_breakpoint
-  --map .
+  --map $<TARGET_FILE_DIR:${EXAMPLE}>
 )

--- a/examples/timer-pwm/CMakeLists.txt
+++ b/examples/timer-pwm/CMakeLists.txt
@@ -33,16 +33,15 @@ target_include_directories(${EXAMPLE} PRIVATE
 
 target_compile_options(${EXAMPLE} PRIVATE
   --core=RV32IMAC
-  -e
+  --dlib_config=full
   --no_wrap_diagnostics
-  --nonportable_path_warnings
 )
 
 target_link_options(${EXAMPLE} PRIVATE
-  --config /opt/iar/cxriscv/riscv/config/linker/GD/GD32VF103xB.icf
+  --config ${TOOLKIT_DIR}/config/linker/GD/GD32VF103xB.icf
   "SHELL:--config_def CSTACK_SIZE=0x1000"
   "SHELL:--config_def HEAP_SIZE=0x1000"
   --redirect __write=__write_buffered
   --debug_lib=iar_breakpoint
-  --map .
+  --map $<TARGET_FILE_DIR:${EXAMPLE}>
 )

--- a/examples/toggle-io/CMakeLists.txt
+++ b/examples/toggle-io/CMakeLists.txt
@@ -32,16 +32,15 @@ target_include_directories(${EXAMPLE} PRIVATE
 
 target_compile_options(${EXAMPLE} PRIVATE
   --core=RV32IMAC
-  -e
+  --dlib_config=full
   --no_wrap_diagnostics
-  --nonportable_path_warnings
 )
 
 target_link_options(${EXAMPLE} PRIVATE
-  --config /opt/iar/cxriscv/riscv/config/linker/GD/GD32VF103xB.icf
+  --config ${TOOLKIT_DIR}/config/linker/GD/GD32VF103xB.icf
   "SHELL:--config_def CSTACK_SIZE=0x1000"
   "SHELL:--config_def HEAP_SIZE=0x1000"
   --redirect __write=__write_buffered
   --debug_lib=iar_breakpoint
-  --map .
+  --map $<TARGET_FILE_DIR:${EXAMPLE}>
 )

--- a/examples/usart/CMakeLists.txt
+++ b/examples/usart/CMakeLists.txt
@@ -32,16 +32,15 @@ target_include_directories(${EXAMPLE} PRIVATE
 
 target_compile_options(${EXAMPLE} PRIVATE
   --core=RV32IMAC
-  -e
+  --dlib_config=full
   --no_wrap_diagnostics
-  --nonportable_path_warnings
 )
 
 target_link_options(${EXAMPLE} PRIVATE
-  --config /opt/iar/cxriscv/riscv/config/linker/GD/GD32VF103xB.icf
+  --config ${TOOLKIT_DIR}/config/linker/GD/GD32VF103xB.icf
   "SHELL:--config_def CSTACK_SIZE=0x1000"
   "SHELL:--config_def HEAP_SIZE=0x1000"
   --redirect __write=__write_buffered
   --debug_lib=iar_breakpoint
-  --map .
+  --map $<TARGET_FILE_DIR:${EXAMPLE}>.
 )


### PR DESCRIPTION
This PR:
- decouples toolchain selection (CX/BX) from CMakePresets.
- Move build selection to outside the CMakeLists, following best practices.